### PR TITLE
Significantly increased performance when a property may be slow or unused

### DIFF
--- a/StringTokenFormatter.Tests/AlternatveTokenMarkerTests.cs
+++ b/StringTokenFormatter.Tests/AlternatveTokenMarkerTests.cs
@@ -154,12 +154,12 @@ namespace StringTokenFormatter.Tests
             string expected = "first second third";
             string input = "first $(two) third";
             var mockTokenMatcher = new Mock<ITokenMatcher>();
-            mockTokenMatcher.Setup(x => x.SplitSegments(input)).Returns(new IMatchingSegment[]
+            mockTokenMatcher.Setup(x => x.SplitSegments(input)).Returns(new SegmentedString(new IMatchingSegment[]
             {
                 new TextMatchingSegment("first "),
                 new TokenMatchingSegment("$(two)", "two", null, null),
                 new TextMatchingSegment(" third"),
-            });
+            }));
             mockTokenMatcher.SetupGet(x => x.TokenNameComparer).Returns(StringComparer.CurrentCultureIgnoreCase);
             mockTokenMatcher.Setup(x => x.RemoveTokenMarkers("$(two)")).Returns("two");
 

--- a/StringTokenFormatter.Tests/PerformanceTests.cs
+++ b/StringTokenFormatter.Tests/PerformanceTests.cs
@@ -31,7 +31,7 @@ namespace StringTokenFormatter.Tests {
             OUTER.Stop();
 
             output.WriteLine($@"OUTER: {OUTER.Elapsed}");
-            output.WriteLine($@"INNER: {OUTER.Elapsed}");
+            output.WriteLine($@"INNER: {INNER.Elapsed}");
         }
 
         //These two methods allow me to see the performance comparison by comparing the elapsed time in the test explorer.

--- a/StringTokenFormatter.Tests/PerformanceTests.cs
+++ b/StringTokenFormatter.Tests/PerformanceTests.cs
@@ -10,12 +10,14 @@ namespace StringTokenFormatter.Tests {
 
         private readonly ITestOutputHelper output;
 
-        public PerformanceTests(ITestOutputHelper output) {
+        public PerformanceTests(ITestOutputHelper output)
+        {
             this.output = output;
         }
 
         [Fact]
-        public void MiscellaneousTest() {
+        public void MiscellaneousTest()
+        {
 
             var OUTER = System.Diagnostics.Stopwatch.StartNew();
             var Args = new ExampleClass();
@@ -23,7 +25,8 @@ namespace StringTokenFormatter.Tests {
 
             var INNER = System.Diagnostics.Stopwatch.StartNew();
 
-            for (int i = 0; i < COUNT; i++) {
+            for (int i = 0; i < COUNT; i++)
+            {
                 Format.FormatToken(Args);
             }
             INNER.Stop();
@@ -36,19 +39,23 @@ namespace StringTokenFormatter.Tests {
 
         //These two methods allow me to see the performance comparison by comparing the elapsed time in the test explorer.
         [Fact]
-        public void SegmentedStringFormat() {
+        public void SegmentedStringFormat()
+        {
             var Args = new ExampleClass();
 
             var Segment = SegmentedString.Create(Format);
-            for (int i = 0; i < COUNT; i++) {
+            for (int i = 0; i < COUNT; i++)
+            {
                 Segment.FormatToken(Args);
             }
         }
 
         [Fact]
-        public void StringFormat() {
+        public void StringFormat()
+        {
             var Args = new ExampleClass();
-            for (int i = 0; i < COUNT; i++) {
+            for (int i = 0; i < COUNT; i++)
+            {
                 Format.FormatToken(Args);
             }
         }
@@ -57,7 +64,8 @@ namespace StringTokenFormatter.Tests {
         const int COUNT = 100_000;
 
 
-        public class ExampleClass {
+        public class ExampleClass
+        {
             public string Property0 { get; set; } = "0";
             public int Property1 { get; set; } = 1;
             public long Property2 { get; set; } = 2;
@@ -71,8 +79,10 @@ namespace StringTokenFormatter.Tests {
 
             public bool Property10 { get; set; } = true;
 
-            public string SlowProperty {
-                get {
+            public string SlowProperty
+            {
+                get 
+                {
                     System.Threading.Thread.Sleep(1);
                     return "Slow!";
                 }

--- a/StringTokenFormatter.Tests/PerformanceTests.cs
+++ b/StringTokenFormatter.Tests/PerformanceTests.cs
@@ -1,0 +1,83 @@
+﻿using Xunit;
+using System.Collections.Generic;
+using Moq;
+using System;
+using Xunit.Abstractions;
+
+namespace StringTokenFormatter.Tests {
+    public class PerformanceTests
+    {
+
+        private readonly ITestOutputHelper output;
+
+        public PerformanceTests(ITestOutputHelper output) {
+            this.output = output;
+        }
+
+        [Fact]
+        public void MiscellaneousTest() {
+
+            var OUTER = System.Diagnostics.Stopwatch.StartNew();
+            var Args = new ExampleClass();
+            var WarmUp = Format.FormatToken(Args);
+
+            var INNER = System.Diagnostics.Stopwatch.StartNew();
+
+            for (int i = 0; i < COUNT; i++) {
+                Format.FormatToken(Args);
+            }
+            INNER.Stop();
+
+            OUTER.Stop();
+
+            output.WriteLine($@"OUTER: {OUTER.Elapsed}");
+            output.WriteLine($@"INNER: {OUTER.Elapsed}");
+        }
+
+        //These two methods allow me to see the performance comparison by comparing the elapsed time in the test explorer.
+        [Fact]
+        public void SegmentedStringFormat() {
+            var Args = new ExampleClass();
+
+            var Segment = SegmentedString.Create(Format);
+            for (int i = 0; i < COUNT; i++) {
+                Segment.FormatToken(Args);
+            }
+        }
+
+        [Fact]
+        public void StringFormat() {
+            var Args = new ExampleClass();
+            for (int i = 0; i < COUNT; i++) {
+                Format.FormatToken(Args);
+            }
+        }
+
+        const string Format = "{Property1} {Property3} {Property5} {Property7} {Property9}";
+        const int COUNT = 100_000;
+
+
+        public class ExampleClass {
+            public string Property0 { get; set; } = "0";
+            public int Property1 { get; set; } = 1;
+            public long Property2 { get; set; } = 2;
+            public DateTime Property3 { get; set; } = DateTime.Now;
+            public string Property4 { get; set; } = "4";
+            public int Property5 { get; set; } = 5;
+            public long Property6 { get; set; } = 6;
+            public DateTimeOffset Property7 { get; set; } = DateTimeOffset.UtcNow;
+            public string Property8 { get; set; } = "8";
+            public int Property9 { get; set; } = 9;
+
+            public bool Property10 { get; set; } = true;
+
+            public string SlowProperty {
+                get {
+                    System.Threading.Thread.Sleep(1);
+                    return "Slow!";
+                }
+            }
+        }
+
+    }
+}

--- a/StringTokenFormatter/Matching/DefaultTokenMatcher.cs
+++ b/StringTokenFormatter/Matching/DefaultTokenMatcher.cs
@@ -15,7 +15,8 @@ namespace StringTokenFormatter
         private readonly string segmentPattern;
         private readonly Regex segmentRegex;
 
-        public DefaultTokenMatcher(TokenMarkers tokenMarkers) {
+        public DefaultTokenMatcher(TokenMarkers tokenMarkers)
+        {
             markers = tokenMarkers ?? throw new ArgumentNullException(nameof(tokenMarkers));
             string regexEscapedStartToken = Regex.Escape(markers.StartToken);
             string regexEscapedEscapedStartToken = Regex.Escape(markers.StartTokenEscaped);
@@ -28,11 +29,13 @@ namespace StringTokenFormatter
             : this(new DefaultTokenMarkers()) {
         }
 
-        public SegmentedString SplitSegments(string Input) {
+        public SegmentedString SplitSegments(string Input)
+        {
             return new SegmentedString(SplitSegmentsInternal(Input));
         }
 
-        private IEnumerable<IMatchingSegment> SplitSegmentsInternal(string input) {
+        private IEnumerable<IMatchingSegment> SplitSegmentsInternal(string input)
+        {
             if (string.IsNullOrEmpty(input)) yield break;
             int index = 0;
             foreach (Match match in segmentRegex.Matches(input)) {
@@ -41,11 +44,16 @@ namespace StringTokenFormatter
                     string text = input.Substring(index, match.Index - index);
                     yield return new TextMatchingSegment(text);
                 }
-                if (segment == markers.StartTokenEscaped) {
+                if (segment == markers.StartTokenEscaped)
+                {
                     yield return new TextMatchingSegment(markers.StartToken);
-                } else if (!segment.StartsWith(markers.StartToken)) {
+                }
+                else if (!segment.StartsWith(markers.StartToken))
+                {
                     yield return new TextMatchingSegment(segment);
-                } else {
+                }
+                else
+                {
                     int middleLength = segment.Length - markers.StartToken.Length - markers.EndToken.Length;
                     string tripleWithoutMarkers = segment.Substring(markers.StartToken.Length, middleLength);
                     string[] split = tokenTripleRegex.Split(tripleWithoutMarkers);
@@ -53,12 +61,14 @@ namespace StringTokenFormatter
                 }
                 index = match.Index + match.Length;
             }
-            if (index < input.Length) {
+            if (index < input.Length)
+            {
                 yield return new TextMatchingSegment(input.Substring(index));
             }
         }
 
-        public string RemoveTokenMarkers(string token) {
+        public string RemoveTokenMarkers(string token)
+        {
             if (token.StartsWith(markers.StartToken) && !token.StartsWith(markers.StartTokenEscaped)) {
                 string strippedToken = token.Remove(0, markers.StartToken.Length);
 
@@ -72,7 +82,8 @@ namespace StringTokenFormatter
 
         public IEqualityComparer<string> TokenNameComparer => markers.TokenNameComparer;
 
-        public IEnumerable<string> MatchedTokens(string input) {
+        public IEnumerable<string> MatchedTokens(string input)
+        {
             return SplitSegments(input).OfType<TokenMatchingSegment>().Select(x => x.Token);
         }
     }

--- a/StringTokenFormatter/Matching/DefaultTokenMatcher.cs
+++ b/StringTokenFormatter/Matching/DefaultTokenMatcher.cs
@@ -9,6 +9,8 @@ namespace StringTokenFormatter
         private static readonly string regexEscapedPaddingSeparator = Regex.Escape(",");
         private static readonly string regexEscapedFormattingSeparator = Regex.Escape(":");
         private static readonly string tokenTriplePattern = $"^([^{regexEscapedPaddingSeparator}{regexEscapedFormattingSeparator}]*){regexEscapedPaddingSeparator}?([^{regexEscapedFormattingSeparator}]*){regexEscapedFormattingSeparator }?(.*)$";
+        private static readonly Regex tokenTripleRegex = new Regex(tokenTriplePattern, RegexOptions.Compiled | RegexOptions.Singleline);
+
         private readonly TokenMarkers markers;
         private readonly string segmentPattern;
         private readonly Regex segmentRegex;
@@ -46,7 +48,7 @@ namespace StringTokenFormatter
                 } else {
                     int middleLength = segment.Length - markers.StartToken.Length - markers.EndToken.Length;
                     string tripleWithoutMarkers = segment.Substring(markers.StartToken.Length, middleLength);
-                    string[] split = Regex.Split(tripleWithoutMarkers, tokenTriplePattern, RegexOptions.Singleline);
+                    string[] split = tokenTripleRegex.Split(tripleWithoutMarkers);
                     yield return new TokenMatchingSegment(segment, split[1], split[2], split[3]);
                 }
                 index = match.Index + match.Length;

--- a/StringTokenFormatter/Matching/ITokenMatcher.cs
+++ b/StringTokenFormatter/Matching/ITokenMatcher.cs
@@ -4,7 +4,7 @@ namespace StringTokenFormatter
 {
     public interface ITokenMatcher
     {
-        IEnumerable<IMatchingSegment> SplitSegments(string input);
+        SegmentedString SplitSegments(string input);
         string RemoveTokenMarkers(string token);
         IEqualityComparer<string> TokenNameComparer { get; }
     }

--- a/StringTokenFormatter/Matching/SegmentedString.cs
+++ b/StringTokenFormatter/Matching/SegmentedString.cs
@@ -13,19 +13,23 @@ namespace StringTokenFormatter {
             segments = allsegments.ToList();
         }
 
-        public IEnumerator<IMatchingSegment> GetEnumerator() {
+        public IEnumerator<IMatchingSegment> GetEnumerator()
+        {
             return segments.GetEnumerator();
         }
 
-        IEnumerator IEnumerable.GetEnumerator() {
+        IEnumerator IEnumerable.GetEnumerator()
+        {
             return segments.GetEnumerator();
         }
 
-        public static SegmentedString Create(string input) {
+        public static SegmentedString Create(string input)
+        {
             return Create(input, TokenReplacer.DefaultMatcher);
         }
 
-        public static SegmentedString Create(string input, ITokenMatcher Matcher) {
+        public static SegmentedString Create(string input, ITokenMatcher Matcher)
+        {
             return Matcher.SplitSegments(input);
         }
     }

--- a/StringTokenFormatter/Matching/SegmentedString.cs
+++ b/StringTokenFormatter/Matching/SegmentedString.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace StringTokenFormatter {
+    public class SegmentedString : IEnumerable<IMatchingSegment> {
+        private List<IMatchingSegment> segments;
+
+        public SegmentedString(IEnumerable<IMatchingSegment> allsegments)
+        {
+            segments = allsegments.ToList();
+        }
+
+        public IEnumerator<IMatchingSegment> GetEnumerator() {
+            return segments.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() {
+            return segments.GetEnumerator();
+        }
+
+        public static SegmentedString Create(string input) {
+            return Create(input, TokenReplacer.DefaultMatcher);
+        }
+
+        public static SegmentedString Create(string input, ITokenMatcher Matcher) {
+            return Matcher.SplitSegments(input);
+        }
+    }
+}

--- a/StringTokenFormatter/SegmentedStringExtensions.cs
+++ b/StringTokenFormatter/SegmentedStringExtensions.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace StringTokenFormatter
+{
+    public static class SegmentedStringTokenExtensions
+    {
+        /// <summary>
+        /// Replaces each instance of the single format token in the specified string with the text equivalent of a corresponding object's value.
+        /// </summary>
+        /// <param name="input">The string containing the token to be replaced.</param>
+        /// <param name="token">The token to be replaced.</param>
+        /// <param name="replacementValue">The replacement value.</param>
+        /// <returns>A copy of input in which the format tokens have been replaced by the string representation of the corresponding object's values.</returns>
+        public static string FormatToken(this SegmentedString input, string token, object replacementValue)
+        {
+            return FormatToken(input, null, token, replacementValue);
+        }
+
+        /// <summary>
+        /// Replaces each instance of the single format token in the specified string with the text equivalent of a corresponding object's value using the format provider specified.
+        /// </summary>
+        /// <param name="input">The string containing the token to be replaced.</param>
+        /// <param name="provider">The formatting provider.</param>
+        /// <param name="token">The token to be replaced.</param>
+        /// <param name="replacementValue">The replacement value.</param>
+        /// <returns>A copy of input in which the format tokens have been replaced by the string representation of the corresponding object's values.</returns>
+        public static string FormatToken(this SegmentedString input, IFormatProvider provider, string token, object replacementValue)
+        {
+            return new TokenReplacer(TokenReplacer.DefaultMatcher, TokenReplacer.DefaultMappers, new FormatProviderValueFormatter(provider)).FormatFromSingle(input, token, replacementValue);
+        }
+
+        /// <summary>
+        /// Replaces each format token in a specified string with the equivalent matching token object's text equivalent value.
+        /// </summary>
+        /// <param name="input">The string containing the tokens to be replaced.</param>
+        /// <param name="tokenValues">The token keys and associated values.</param>
+        /// <returns>A copy of input in which the format tokens have been replaced by the string representation of the corresponding object's values.</returns>
+        public static string FormatToken(this SegmentedString input, IDictionary<string, object> tokenValues)
+        {
+            return FormatToken(input, null, tokenValues);
+        }
+
+        /// <summary>
+        /// Replaces each format token in a specified string with the equivalent matching token object's text equivalent value using the format provider specified.
+        /// </summary>
+        /// <param name="input">The string containing the tokens to be replaced.</param>
+        /// <param name="provider">The formatting provider.</param>
+        /// <param name="tokenValues">The token keys and associated values.</param>
+        /// <returns>A copy of input in which the format tokens have been replaced by the string representation of the corresponding object's values.</returns>
+        public static string FormatToken(this SegmentedString input, IFormatProvider provider, IDictionary<string, object> tokenValues)
+        {
+            return new TokenReplacer(TokenReplacer.DefaultMatcher, TokenReplacer.DefaultMappers, new FormatProviderValueFormatter(provider)).FormatFromDictionary(input, tokenValues);
+        }
+
+        /// <summary>
+        /// Replaces each format token in a specified string with the equivalent property's text equivalent value in the object.
+        /// </summary>
+        /// <param name="input">The string containing the token to be replaced.</param>
+        /// <param name="tokenValues">The object containing the property values to be used in replacements.</param>
+        /// <returns>A copy of input in which the format tokens have been replaced by the string representation of the corresponding object's values.</returns>
+        public static string FormatToken(this SegmentedString input, object tokenValues)
+        {
+            return FormatToken(input, (IFormatProvider)null, tokenValues);
+        }
+
+        /// <summary>
+        /// Replaces each format token in a specified string with the equivalent property's text equivalent value using the format provider specified.
+        /// </summary>
+        /// <param name="input">The string containing the token to be replaced.</param>
+        /// <param name="provider">The formatting provider.</param>
+        /// <param name="tokenValues">The object containing the property values to be used in replacements.</param>
+        /// <returns>A copy of input in which the format tokens have been replaced by the string representation of the corresponding object's values.</returns>
+        public static string FormatToken(this SegmentedString input, IFormatProvider provider, object tokenValues)
+        {
+            return new TokenReplacer(TokenReplacer.DefaultMatcher, TokenReplacer.DefaultMappers, new FormatProviderValueFormatter(provider)).FormatFromProperties(input, tokenValues);
+        }
+
+        /// <summary>
+        /// Replaces each format token in a specified string with the equivalent matching token's string value.
+        /// </summary>
+        /// <param name="input">The string containing the tokens to be replaced.</param>
+        /// <param name="tokenValues">The token keys and associated values.</param>
+        /// <returns>A copy of input in which the format tokens have been replaced by the string representation of the corresponding object's values.</returns>
+        public static string FormatToken(this SegmentedString input, IDictionary<string, string> tokenValues)
+        {
+            return FormatToken(input, null, tokenValues);
+        }
+
+        /// <summary>
+        /// Replaces each format token in a specified string with the equivalent matching token's string value using the format provider specified.
+        /// </summary>
+        /// <param name="input">The string containing the tokens to be replaced.</param>
+        /// <param name="provider">The formatting provider.</param>
+        /// <param name="tokenValues">The token keys and associated values.</param>
+        /// <returns>A copy of input in which the format tokens have been replaced by the string representation of the corresponding object's values.</returns>
+        public static string FormatToken(this SegmentedString input, IFormatProvider provider, IDictionary<string, string> tokenValues)
+        {
+            return new TokenReplacer(TokenReplacer.DefaultMatcher, TokenReplacer.DefaultMappers, new FormatProviderValueFormatter(provider)).FormatFromDictionary(input, tokenValues);
+        }
+    }
+}

--- a/StringTokenFormatter/TokenReplacer.cs
+++ b/StringTokenFormatter/TokenReplacer.cs
@@ -46,20 +46,24 @@ namespace StringTokenFormatter
             new TokenToFunctionObjectValueMapper(),
         };
 
-        public string FormatFromProperties(string input, object propertyContainer) {
+        public string FormatFromProperties(string input, object propertyContainer)
+        {
             return FormatFromProperties(matcher.SplitSegments(input), propertyContainer);
         }
 
-        public string FormatFromProperties(SegmentedString input, object propertyContainer) {
+        public string FormatFromProperties(SegmentedString input, object propertyContainer)
+        {
             ITokenValueContainer mapper = new ObjectPropertiesTokenValueContainer(propertyContainer, matcher);
             return MapTokens(input, mapper);
         }
 
-        public string FormatFromDictionary(string input, IDictionary<string, object> tokenValues) {
+        public string FormatFromDictionary(string input, IDictionary<string, object> tokenValues)
+        {
             return FormatFromDictionary(matcher.SplitSegments(input), tokenValues);
         }
 
-        public string FormatFromDictionary(SegmentedString input, IDictionary<string, object> tokenValues) {
+        public string FormatFromDictionary(SegmentedString input, IDictionary<string, object> tokenValues)
+        {
             if (tokenValues == null) throw new ArgumentNullException(nameof(tokenValues));
 
             ITokenValueContainer mapper = new DictionaryTokenValueContainer(tokenValues, matcher);
@@ -67,7 +71,8 @@ namespace StringTokenFormatter
         }
 
 
-        public string FormatFromDictionary(string input, IDictionary<string, string> tokenValues) {
+        public string FormatFromDictionary(string input, IDictionary<string, string> tokenValues)
+        {
             return FormatFromDictionary(matcher.SplitSegments(input), tokenValues);
         }
 

--- a/StringTokenFormatter/TokenReplacer.cs
+++ b/StringTokenFormatter/TokenReplacer.cs
@@ -5,34 +5,28 @@ using System.Text;
 
 namespace StringTokenFormatter
 {
-    public class TokenReplacer
-    {
+    public class TokenReplacer {
         private readonly ITokenMatcher matcher;
         private readonly IValueFormatter formatter;
         private readonly TokenToValueCompositeMapper mapper;
 
         public TokenReplacer()
-            : this(DefaultMatcher, DefaultMappers, DefaultFormatter)
-        {
+            : this(DefaultMatcher, DefaultMappers, DefaultFormatter) {
         }
 
         public TokenReplacer(TokenMarkers markers)
-            : this(new DefaultTokenMatcher(markers), DefaultMappers, DefaultFormatter)
-        {
+            : this(new DefaultTokenMatcher(markers), DefaultMappers, DefaultFormatter) {
         }
 
         public TokenReplacer(IFormatProvider provider)
-            : this(DefaultMatcher, DefaultMappers, new FormatProviderValueFormatter(provider))
-        {
+            : this(DefaultMatcher, DefaultMappers, new FormatProviderValueFormatter(provider)) {
         }
 
         public TokenReplacer(TokenMarkers markers, IFormatProvider provider)
-            : this(new DefaultTokenMatcher(markers), DefaultMappers, new FormatProviderValueFormatter(provider))
-        {
+            : this(new DefaultTokenMatcher(markers), DefaultMappers, new FormatProviderValueFormatter(provider)) {
         }
 
-        public TokenReplacer(ITokenMatcher tokenMatcher, IEnumerable<ITokenToValueMapper> valueMappers, IValueFormatter valueFormatter)
-        {
+        public TokenReplacer(ITokenMatcher tokenMatcher, IEnumerable<ITokenToValueMapper> valueMappers, IValueFormatter valueFormatter) {
             matcher = tokenMatcher ?? throw new ArgumentNullException(nameof(tokenMatcher));
             if (valueMappers == null) throw new ArgumentNullException(nameof(valueMappers));
             mapper = new TokenToValueCompositeMapper(valueMappers);
@@ -52,40 +46,55 @@ namespace StringTokenFormatter
             new TokenToFunctionObjectValueMapper(),
         };
 
-        public string FormatFromProperties(string input, object propertyContainer)
-        {
+        public string FormatFromProperties(string input, object propertyContainer) {
+            return FormatFromProperties(matcher.SplitSegments(input), propertyContainer);
+        }
+
+        public string FormatFromProperties(SegmentedString input, object propertyContainer) {
             ITokenValueContainer mapper = new ObjectPropertiesTokenValueContainer(propertyContainer, matcher);
             return MapTokens(input, mapper);
         }
 
-        public string FormatFromDictionary(string input, IDictionary<string, object> tokenValues)
-        {
+        public string FormatFromDictionary(string input, IDictionary<string, object> tokenValues) {
+            return FormatFromDictionary(matcher.SplitSegments(input), tokenValues);
+        }
+
+        public string FormatFromDictionary(SegmentedString input, IDictionary<string, object> tokenValues) {
             if (tokenValues == null) throw new ArgumentNullException(nameof(tokenValues));
 
             ITokenValueContainer mapper = new DictionaryTokenValueContainer(tokenValues, matcher);
             return MapTokens(input, mapper);
         }
 
-        public string FormatFromDictionary(string input, IDictionary<string, string> tokenValues)
+
+        public string FormatFromDictionary(string input, IDictionary<string, string> tokenValues) {
+            return FormatFromDictionary(matcher.SplitSegments(input), tokenValues);
+        }
+
+        public string FormatFromDictionary(SegmentedString input, IDictionary<string, string> tokenValues)
         {
             if (tokenValues == null) throw new ArgumentNullException(nameof(tokenValues));
             var tokenValues2 = tokenValues.ToDictionary(p => p.Key, p => (object)p.Value);
             return FormatFromDictionary(input, tokenValues2);
         }
 
-        public string FormatFromSingle(string input, string token, object value)
+        public string FormatFromSingle(string input, string token, object value) {
+            return FormatFromSingle(matcher.SplitSegments(input), token, value);
+        }
+
+        public string FormatFromSingle(SegmentedString input, string token, object value)
         {
             ITokenValueContainer mapper = new SingleTokenValueContainer(token, value, matcher);
             return MapTokens(input, mapper);
         }
 
-        public string MapTokens(string input, ITokenValueContainer container)
+        public string MapTokens(SegmentedString input, ITokenValueContainer container)
         {
-            if (string.IsNullOrEmpty(input)) return input;
+            if (input == null) throw new ArgumentNullException(nameof(input));
             if (container == null) throw new ArgumentNullException(nameof(container));
 
             StringBuilder sb = new StringBuilder();
-            foreach (var segment in matcher.SplitSegments(input))
+            foreach (var segment in input)
             {
                 if (segment is TextMatchingSegment textSegment)
                 {

--- a/StringTokenFormatter/TokenReplacer.cs
+++ b/StringTokenFormatter/TokenReplacer.cs
@@ -83,7 +83,8 @@ namespace StringTokenFormatter
             return FormatFromDictionary(input, tokenValues2);
         }
 
-        public string FormatFromSingle(string input, string token, object value) {
+        public string FormatFromSingle(string input, string token, object value)
+        {
             return FormatFromSingle(matcher.SplitSegments(input), token, value);
         }
 


### PR DESCRIPTION
I did a number of performance tests on different variations/combinations of the two following concepts:
* Creating the mappings only when requested
* Wrapping the mappings in a lazy

The best performing result was to create all the mappings up front and wrap them in the lazy.

Creating the mappings on demand decreased the performance because it resulted in two dictionary lookups instead of one.  (See if value has been generated, if it hasn't fetch it).

This enhancement is good because:
* it is faster
* it only actually retrieves values for variables that are used.
* if a variable is slow and unused, it will now have no bearing on performance.

