### PR TITLE
Added async support

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,37 @@ The default implementation uses the current culture to provide formatting inform
 
 To create your own, either implement the ```ITokenValueFormatter``` interface or call ```TokenValueFormatter.From(IFormatProvider)```.
 
+## Async support
+Whilst not a core feature, it is possible to use async/await. The ```SegmentedString``` class includes a ```FormatAsync``` method which takes an
+```ITokenValueContainerAsync```. No concrete implementations are provided at this time. Example:
+
+``` C#
+class Container : ITokenValueContainerAsync
+{
+    public async Task<bool> TryMapAsync(IMatchedToken matchedToken, out object? mapped)
+    {
+        var result = await ExternalCallAsync(matchedToken.Token);
+
+        if (result.IsMappedSuccessfully) {
+            mapped = result.MappedValue;
+            return true;
+        }
+
+        mapped = null;
+        return false;
+    }
+}
+
+...
+
+public async Task<string> FormatStringAsync(string original)
+{
+    var container = new Container();
+    var segments = SegmentedString.Parse(original, null);
+    return await segments.FormatAsync(container, default, default);
+}
+```
+
 # Upgrading from v3.x
 Version 4.x of StringTokenFormatter is a major upgrade and has a number of enhancements compared to 3.x.
 

--- a/StringTokenFormatter.Tests/FormatAsyncTests.cs
+++ b/StringTokenFormatter.Tests/FormatAsyncTests.cs
@@ -1,0 +1,34 @@
+using System;
+using Xunit;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace StringTokenFormatter.Tests
+{
+    public class FormatAsyncTests
+    {
+        class Container : ITokenValueContainerAsync
+        {
+            public Task<bool> TryMapAsync(IMatchedToken matchedToken, out object? mapped)
+            {
+                if (matchedToken.Token == "token") {
+                    mapped = "mapped";
+                    return Task.FromResult(true);
+                }
+                mapped = null;
+                return Task.FromResult(false);
+            }
+        }
+
+        [Fact]
+        public async Task Formatting_Single_Value_Using_A_Function_Returns_In_Mapped_String()
+        {
+            var container = new Container();
+            var segments = new SegmentedString(new ISegment[] { new StringSegment("text"), new TokenSegment("{token}", "token", default, default) });
+
+            var actual = await segments.FormatAsync(container, default, default);
+
+            Assert.Equal("textmapped", actual);
+        }
+    }
+}

--- a/StringTokenFormatter/Containers/ITokenValueContainerAsync.cs
+++ b/StringTokenFormatter/Containers/ITokenValueContainerAsync.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+
+namespace StringTokenFormatter {
+
+    public interface ITokenValueContainerAsync {
+        Task<bool> TryMapAsync(IMatchedToken matchedToken, out object? mapped);
+    }
+
+}

--- a/StringTokenFormatter/Matching/ISegment.cs
+++ b/StringTokenFormatter/Matching/ISegment.cs
@@ -1,9 +1,13 @@
-﻿namespace StringTokenFormatter {
+﻿using System.Threading.Tasks;
+
+namespace StringTokenFormatter {
 
     public interface ISegment {
         string Original { get; }
 
         string? Evaluate(ITokenValueContainer container, ITokenValueFormatter formatter, ITokenValueConverter converter);
+
+        Task<string?> EvaluateAsync(ITokenValueContainerAsync container, ITokenValueFormatter formatter, ITokenValueConverter converter);
 
     }
 

--- a/StringTokenFormatter/Matching/SegmentedString.cs
+++ b/StringTokenFormatter/Matching/SegmentedString.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace StringTokenFormatter {
 
@@ -28,6 +29,20 @@ namespace StringTokenFormatter {
             
             foreach (var segment in Segments) {
                 sb.Append(segment.Evaluate(container, formatter, converter));
+            }
+
+            return sb.ToString();
+        }
+
+        public async Task<string> FormatAsync(ITokenValueContainerAsync container, ITokenValueFormatter? formatter = default, ITokenValueConverter? converter = default) {
+            if (container == null) throw new ArgumentNullException(nameof(container));
+            converter ??= TokenValueConverter.Default;
+            formatter ??= TokenValueFormatter.Default;
+
+            var sb = new StringBuilder();
+
+            foreach (var segment in Segments) {
+                sb.Append(await segment.EvaluateAsync(container, formatter, converter));
             }
 
             return sb.ToString();

--- a/StringTokenFormatter/Matching/StringSegment.cs
+++ b/StringTokenFormatter/Matching/StringSegment.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Threading.Tasks;
 
 namespace StringTokenFormatter {
 
@@ -13,6 +14,10 @@ namespace StringTokenFormatter {
 
         public string? Evaluate(ITokenValueContainer container, ITokenValueFormatter formatter, ITokenValueConverter converter) {
             return formatter.Format(this, Original, null, null);
+        }
+
+        public Task<string?> EvaluateAsync(ITokenValueContainerAsync container, ITokenValueFormatter formatter, ITokenValueConverter converter) {
+            return Task.FromResult(formatter.Format(this, Original, null, null));
         }
 
         public override string ToString() => Original;

--- a/StringTokenFormatter/Matching/TokenSegment.cs
+++ b/StringTokenFormatter/Matching/TokenSegment.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Threading.Tasks;
 
 namespace StringTokenFormatter {
 
@@ -22,11 +23,21 @@ namespace StringTokenFormatter {
 
             if (container.TryMap(this, out var value1)) {
 
-                if (converter.TryConvert(this, value1, out var value2)) {
-                    mappedValue = value2;
-                } else {
-                    mappedValue = value1;
-                }
+                mappedValue = converter.TryConvert(this, value1, out var value2) ? value2 : value1;
+
+            }
+
+            var ret = formatter.Format(this, mappedValue, Padding, Format);
+
+            return ret;
+        }
+
+        public async Task<string?> EvaluateAsync(ITokenValueContainerAsync container, ITokenValueFormatter formatter, ITokenValueConverter converter) {
+            object? mappedValue = Original;
+
+            if (await container.TryMapAsync(this, out var value1)) {
+
+                mappedValue = converter.TryConvert(this, value1, out var value2) ? value2 : value1;
 
             }
 


### PR DESCRIPTION
I've added a new container async interface and implemented it through to SegmentedString. I haven't created any extension methods nor implemented the interface in any of the existing containers because I'd say the use cases are unclear. 

There is one bit
```C#
foreach (var segment in Segments) {
  sb.Append(await segment.EvaluateAsync(container, formatter, converter));
}
```

which I feel could be written in a different way with async (using WhenAll for example) however, again I'm unclear as to the use cases so I think this is sufficient for now. For me, because going off to an external resource is slow, batching up the tokens might be a better fit.

Let me know what you think.